### PR TITLE
Fix CPU compute unit not being passed to model load

### DIFF
--- a/apps/geniex_chat_android/src/main/java/com/geniex/demo/MainActivity.kt
+++ b/apps/geniex_chat_android/src/main/java/com/geniex/demo/MainActivity.kt
@@ -856,6 +856,8 @@ class MainActivity : FragmentActivity() {
                         } else if (checkedId == R.id.rb_npu) {
                             nGpuLayers = 999
                             ggufLlmDeviceId = ComputeUnitValue.NPU.value
+                        } else if (checkedId == R.id.rb_cpu) {
+                            ggufLlmDeviceId = ComputeUnitValue.CPU.value
                         }
                         when (which) {
                             DialogInterface.BUTTON_POSITIVE -> {


### PR DESCRIPTION
Selecting CPU in the picker dialog left the device ID null, which silently fell back to a hardcoded NPU/HTP0 default. This broke model loading on non-Qualcomm hardware (for example, Google Pixel/Tensor devices) that does not have an HTP.

Steps to reproduce

1. Install the app on a Google Pixel device (Google Tensor SoC, no Qualcomm Hexagon HTP), such as Pixel 8/9.
2. Open the model list and select any GGUF/llama.cpp model (runtime: llama_cpp), for example Qwen3-0.6B-GGUF.
3. Download the model. This completes successfully regardless of the chipset.
4. Tap to load the model. In the compute-unit picker dialog, leave the default selection (CPU is pre-checked) and tap OK.
5. Observe that loading fails with a native error from LlmWrapper.builder()...build(), even though CPU was selected.
6. Expected behavior: The model should load using CPU as selected.